### PR TITLE
Added bazel shutdown after executing bazel commands

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -41,6 +41,9 @@ cp -r ${RECIPE_DIR}/tutorial .
 cd tutorial
 bazel build "${BAZEL_BUILD_OPTS[@]}" //main:hello-world
 bazel info | grep "java-home.*embedded_tools"
+bazel shutdown
+bazel clean --expunge
+
 
 if [[ ${HOST} =~ .*linux.* ]]; then
     # libstdc++ should not be included in this listing as it is statically linked

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 0006-Add-support-for-ppc64le-embedded-jdk.patch 
 
 build:
-  number: 1
+  number: 2
   ignore_prefix_files: True
   binary_relocation: False  # [osx]
 


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Fixes an issue wherein bazel process wasn't being killed after building bazel itself. And mostly during full builds, we used to see resource issues when more bazel builds are run. The most impacted package used to tensorflow-text which gets built at the end.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
