### PR TITLE
[1.1,1.2] Remove runtime libgcc pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,12 +11,9 @@ source:
     - 0006-Add-support-for-ppc64le-embedded-jdk.patch 
 
 build:
-  number: 4
+  number: 5
   ignore_prefix_files: True
   binary_relocation: False  # [osx]
-  ignore_run_exports:
-    - libgcc-ng
-    - libstdcxx-ng
 
 requirements:
   build:
@@ -36,9 +33,6 @@ requirements:
 
   run:
     - posix  # [win]
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
 
 test:
   requires:


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Adjust libgcc and libstdc++ runtime dependencies for xgboost

open-ce/open-ce#452

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
