### PR TITLE
Added s390x support for Bazel 3.7.2

### DIFF
--- a/recipe/0102-Fixed-Java-heap-OOM-s390x.patch
+++ b/recipe/0102-Fixed-Java-heap-OOM-s390x.patch
@@ -1,0 +1,27 @@
+diff --git a/scripts/bootstrap/compile.sh b/scripts/bootstrap/compile.sh
+index 9e128df..02548f6 100755
+--- a/scripts/bootstrap/compile.sh
++++ b/scripts/bootstrap/compile.sh
+@@ -144,7 +144,7 @@ function java_compilation() {
+   # Useful if your system chooses too small of a max heap for javac.
+   # We intentionally rely on shell word splitting to allow multiple
+   # additional arguments to be passed to javac.
+-  run "${JAVAC}" -classpath "${classpath}" -sourcepath "${sourcepath}" \
++  run "${JAVAC}" -J-Xms2g -J-Xmx2g -classpath "${classpath}" -sourcepath "${sourcepath}" \
+       -d "${output}/classes" -source "$JAVA_VERSION" -target "$JAVA_VERSION" \
+       -encoding UTF-8 ${BAZEL_JAVAC_OPTS} "@${paramfile}"
+ 
+diff --git a/tools/build_rules/java_rules_skylark.bzl b/tools/build_rules/java_rules_skylark.bzl
+index 64bad95..c57e013 100755
+--- a/tools/build_rules/java_rules_skylark.bzl
++++ b/tools/build_rules/java_rules_skylark.bzl
+@@ -69,7 +69,7 @@ def _java_library_impl(ctx):
+         cmd += "%s/bin/javac" % java_runtime.java_home
+         cmd += " " + " ".join(javac_options)
+         if compile_time_jars:
+-            cmd += " -classpath '" + cmd_helper.join_paths(ctx.configuration.host_path_separator, compile_time_jars) + "'"
++            cmd += " -J-Xms2g -J-Xmx2g -classpath '" + cmd_helper.join_paths(ctx.configuration.host_path_separator, compile_time_jars) + "'"
+         cmd += " -d " + build_output + files + "\n"
+ 
+     # We haven't got a good story for where these should end up, so
+

--- a/recipe/0103-Fixed-ByteOrder-md5digest-state-value-s390x.patch
+++ b/recipe/0103-Fixed-ByteOrder-md5digest-state-value-s390x.patch
@@ -1,0 +1,142 @@
+diff --git a/src/main/cpp/util/md5.cc b/src/main/cpp/util/md5.cc
+index 1c91bab570..ea66285542 100755
+--- a/src/main/cpp/util/md5.cc
++++ b/src/main/cpp/util/md5.cc
+@@ -41,7 +41,7 @@
+ 
+ #include <stddef.h>  // for offsetof
+ #include <string.h>  // for memcpy
+-
++#include <byteswap.h> // for byteswap
+ #include <cinttypes>
+ 
+ #if !_STRING_ARCH_unaligned
+@@ -160,6 +160,10 @@ void Md5Digest::Finish(unsigned char digest[16]) {
+   /* Put the 64-bit file length in *bits* at the end of the buffer.  */
+   unsigned int size = (ctx_buffer_len < 56 ? 64 : 128);
+   uint32_t words[2] = { count[0] << 3, (count[1] << 3) | (count[0] >> 29) };
++
++  words[0] = bswap_32(words[0]);
++  words[1] = bswap_32(words[1]);
++
+   memcpy(ctx_buffer + size - 8, words, 8);
+ 
+   memcpy(ctx_buffer + ctx_buffer_len, kPadding, size - 8 - ctx_buffer_len);
+@@ -206,10 +210,18 @@ void Md5Digest::Transform(
+   // ROTATE_LEFT rotates x left n bits.
+ #define ROTATE_LEFT(x, n) (((x) << (n)) | ((x) >> (32-(n))))
+ 
++// SET reads 4 input bytes in little-endian byte order and stores them
++// in a properly aligned word in host byte order.
++#define SET(n)                                                                 \
++   (x[(n)] =                                                                \
++        (uint32_t) ptr[(n) * 4] | ((uint32_t) ptr[(n) * 4 + 1] << 8) |    \
++        ((uint32_t) ptr[(n) * 4 + 2] << 16) |                                \
++        ((uint32_t) ptr[(n) * 4 + 3] << 24))
++
+   // FF, GG, HH, and II transformations for rounds 1, 2, 3, and 4.
+   // Rotation is separate from addition to prevent recomputation.
+-#define FF(a, b, c, d, s, ac) { \
+-      (a) += F((b), (c), (d)) + ((*x_pos++ = *cur_word++)) + \
++#define FF(a, b, c, d, s, x, ac) { \
++      (a) += F((b), (c), (d)) + (x) + \
+           static_cast<uint32_t>(ac); \
+       (a) = ROTATE_LEFT((a), (s)); \
+       (a) += (b); \
+@@ -242,33 +254,33 @@ void Md5Digest::Transform(
+   uint32_t d = state[3];
+   uint32_t x[16];
+ 
+-  const uint32_t *cur_word = reinterpret_cast<const uint32_t*>(buffer);
+-  const uint32_t *end_word = cur_word + (len / sizeof(uint32_t));
++  const uint8_t *ptr = reinterpret_cast<const uint8_t*>(buffer);
++  // const uint32_t *cur_word = reinterpret_cast<const uint32_t*>(buffer);
++  // const uint32_t *end_word = cur_word + (len / sizeof(uint32_t));
+ 
+-  while (cur_word < end_word) {
+-    uint32_t *x_pos = x;
++  do {
+     uint32_t prev_a = a;
+     uint32_t prev_b = b;
+     uint32_t prev_c = c;
+     uint32_t prev_d = d;
+ 
+     // Round 1
+-    FF(a, b, c, d, S11, 0xd76aa478);  // 1
+-    FF(d, a, b, c, S12, 0xe8c7b756);  // 2
+-    FF(c, d, a, b, S13, 0x242070db);  // 3
+-    FF(b, c, d, a, S14, 0xc1bdceee);  // 4
+-    FF(a, b, c, d, S11, 0xf57c0faf);  // 5
+-    FF(d, a, b, c, S12, 0x4787c62a);  // 6
+-    FF(c, d, a, b, S13, 0xa8304613);  // 7
+-    FF(b, c, d, a, S14, 0xfd469501);  // 8
+-    FF(a, b, c, d, S11, 0x698098d8);  // 9
+-    FF(d, a, b, c, S12, 0x8b44f7af);  // 10
+-    FF(c, d, a, b, S13, 0xffff5bb1);  // 11
+-    FF(b, c, d, a, S14, 0x895cd7be);  // 12
+-    FF(a, b, c, d, S11, 0x6b901122);  // 13
+-    FF(d, a, b, c, S12, 0xfd987193);  // 14
+-    FF(c, d, a, b, S13, 0xa679438e);  // 15
+-    FF(b, c, d, a, S14, 0x49b40821);  // 16
++    FF(a, b, c, d, S11, SET(0), 0xd76aa478);  // 1
++    FF(d, a, b, c, S12, SET(1), 0xe8c7b756);  // 2
++    FF(c, d, a, b, S13, SET(2), 0x242070db);  // 3
++    FF(b, c, d, a, S14, SET(3), 0xc1bdceee);  // 4
++    FF(a, b, c, d, S11, SET(4), 0xf57c0faf);  // 5
++    FF(d, a, b, c, S12, SET(5), 0x4787c62a);  // 6
++    FF(c, d, a, b, S13, SET(6), 0xa8304613);  // 7
++    FF(b, c, d, a, S14, SET(7), 0xfd469501);  // 8
++    FF(a, b, c, d, S11, SET(8), 0x698098d8);  // 9
++    FF(d, a, b, c, S12, SET(9), 0x8b44f7af);  // 10
++    FF(c, d, a, b, S13, SET(10), 0xffff5bb1);  // 11
++    FF(b, c, d, a, S14, SET(11), 0x895cd7be);  // 12
++    FF(a, b, c, d, S11, SET(12), 0x6b901122);  // 13
++    FF(d, a, b, c, S12, SET(13), 0xfd987193);  // 14
++    FF(c, d, a, b, S13, SET(14), 0xa679438e);  // 15
++    FF(b, c, d, a, S14, SET(15), 0x49b40821);  // 16
+ 
+     // Round 2
+     GG(a, b, c, d, x[ 1], S21, 0xf61e2562);  // 17
+@@ -328,7 +340,8 @@ void Md5Digest::Transform(
+     b += prev_b;
+     c += prev_c;
+     d += prev_d;
+-  }
++    ptr += 64;
++  } while (len -=64);
+ 
+   state[0] = a;
+   state[1] = b;
+@@ -336,9 +349,18 @@ void Md5Digest::Transform(
+   state[3] = d;
+ }
+ 
+-string Md5Digest::String() const {
++static void swapStateByteOrder(unsigned int (&state)[4]){
++  state[0] = bswap_32(state[0]);
++  state[1] = bswap_32(state[1]);
++  state[2] = bswap_32(state[2]);
++  state[3] = bswap_32(state[3]);
++}
++
++string Md5Digest::String() {
+   string result;
++  swapStateByteOrder(state); // the hex function converts the state value in little-endian way, so we reverse the order first
+   b2a_hex(reinterpret_cast<const uint8_t*>(state), &result, 16);
++  swapStateByteOrder(state); // the hex function converts the state value in little-endian way, so we reverse the order first
+   return result;
+ }
+ 
+diff --git a/src/main/cpp/util/md5.h b/src/main/cpp/util/md5.h
+index 8f8f3aff23..1f83b3eb8f 100755
+--- a/src/main/cpp/util/md5.h
++++ b/src/main/cpp/util/md5.h
+@@ -53,7 +53,7 @@ class Md5Digest {
+ 
+   // Produces a hexadecimal string representation of this digest in the form:
+   // [0-9a-f]{32}
+-  std::string String() const;
++  std::string String();
+ 
+  private:
+   void Transform(const unsigned char* buffer, unsigned int len);

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -30,6 +30,8 @@ if [[ ${target_platform} =~ .*ppc.* ]]; then
   SYSROOT_DIR="${BUILD_PREFIX}"/powerpc64le-conda_cos7-linux-gnu/sysroot/usr/
 elif [[ ${target_platform} =~ .*x86_64.* || ${target_platform} =~ .*linux-64.* ]]; then
   SYSROOT_DIR="${BUILD_PREFIX}"/x86_64-conda_cos6-linux-gnu/sysroot/usr/
+elif [[ ${target_platform} =~ .*s390x.* ]]; then
+  SYSROOT_DIR="${BUILD_PREFIX}"/s390x-conda_cos7-linux-gnu/sysroot/usr/
 fi
 jvm_slug=$(compgen -G "${SYSROOT_DIR}/lib/jvm/java-1.8.0-openjdk-*")
 export JAVA_HOME=${jvm_slug}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,8 @@ source:
   patches:
     # 01xx - patch is specific to open-ce and will always be carried forward and not upstreamed
     - 0101-Add-support-for-ppc64le-embedded-jdk.patch
+    - 0102-Fixed-Java-heap-OOM-s390x.patch                            # [s390x]
+    - 0103-Fixed-ByteOrder-md5digest-state-value-s390x.patch          # [s390x]
     # 03xx - patch temporary to fix a problem that when fixed upstream can be removed
     - 0301-Fixed-build-Patch-from-https-github.com-bazelbuild-b.patch
 


### PR DESCRIPTION

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

- Included md5digest state value byte order fix. 
  ref: `https://github.com/linux-on-ibm-z/scripts/blob/8ef36d76cf01c0a9b6c17e3aff6d089010140a08/Bazel/3.7.2/patch/bazel.patch#L66`
- Increase Java heap size to fix `Out of Memory` issue.

**Note:** : embedded JDK support in bazel  3.7.2 for s390x is already present via `https://github.com/bazelbuild/bazel/pull/11965` 

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
